### PR TITLE
Implement checkout-ready cart experience

### DIFF
--- a/src/app/cart/CartPage.module.scss
+++ b/src/app/cart/CartPage.module.scss
@@ -1,0 +1,246 @@
+@use "@/styles/variables" as *;
+
+.cart {
+  padding: 32px 0 56px;
+}
+
+.header {
+  margin-bottom: 24px;
+
+  h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(28px, 4vw, 36px);
+    font-weight: 700;
+  }
+
+  p {
+    margin-top: 4px;
+    color: var(--gray-600);
+  }
+}
+
+.headerTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.clearButton {
+  background: transparent;
+  border: 0;
+  color: var(--gray-600);
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: 0.9rem;
+
+  &:hover {
+    color: var(--brand-red);
+  }
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+
+  @media (min-width: 960px) {
+    grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+    align-items: start;
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.item {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 16px;
+  padding: 16px;
+  background: var(--gray-100);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+
+  @media (max-width: 600px) {
+    grid-template-columns: 80px 1fr;
+  }
+}
+
+.itemImage {
+  width: 100%;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #fff;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.itemBody {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.itemHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.itemTitle {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.removeButton {
+  background: transparent;
+  border: 0;
+  color: var(--gray-600);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: color .2s ease;
+
+  &:hover {
+    color: var(--brand-red);
+  }
+}
+
+.price {
+  font-weight: 700;
+  color: var(--brand-red);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.quantity {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #fff;
+}
+
+.quantityButton {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  font-size: 18px;
+  cursor: pointer;
+  transition: background .2s ease;
+
+  &:hover {
+    background: rgba(0,0,0,0.05);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: .4;
+  }
+}
+
+.quantityInput {
+  width: 48px;
+  border: 0;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.lineTotal {
+  margin-left: auto;
+  font-weight: 600;
+}
+
+.summary {
+  position: sticky;
+  top: calc(72px + env(safe-area-inset-top));
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  background: #fff;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.summaryRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  color: var(--gray-900);
+}
+
+.summaryTotal {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--gray-300);
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.checkoutButton {
+  width: 100%;
+  padding: 12px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--brand-red);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform .15s ease, box-shadow .15s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(227, 6, 19, 0.25);
+  }
+
+  &:disabled {
+    opacity: .5;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+  }
+}
+
+.notice {
+  font-size: 0.85rem;
+  color: var(--gray-600);
+  line-height: 1.4;
+}
+
+.empty {
+  padding: 40px;
+  text-align: center;
+  background: var(--gray-100);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+
+  p {
+    margin-bottom: 16px;
+  }
+
+  a {
+    color: var(--brand-red);
+    font-weight: 600;
+  }
+}

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+import Link from "next/link";
+import Container from "@/components/layout/Container/Container";
+import styles from "./CartPage.module.scss";
+import { useCart } from "@/features/cart/CartContext";
+import { formatCurrency } from "@/lib/format";
+
+const SHIPPING_THRESHOLD_CENTS = 6000; // 60€
+const SHIPPING_COST_CENTS = 490; // 4,90€
+
+export default function CartPage() {
+    const {
+        items,
+        currency,
+        subtotalCents,
+        totalQuantity,
+        increment,
+        decrement,
+        updateQuantity,
+        removeItem,
+        clear,
+    } = useCart();
+
+    const shippingCents = subtotalCents === 0
+        ? 0
+        : subtotalCents >= SHIPPING_THRESHOLD_CENTS
+            ? 0
+            : SHIPPING_COST_CENTS;
+    const totalCents = subtotalCents + shippingCents;
+    const missingForFreeShipping = Math.max(0, SHIPPING_THRESHOLD_CENTS - subtotalCents);
+
+    const handleProceedToCheckout = () => {
+        // Placeholder pour le futur tunnel de paiement
+        console.log("Passage au paiement avec", { items, totalCents });
+        alert("Merci ! Le tunnel de paiement arrive très bientôt.");
+    };
+
+    return (
+        <Container>
+            <section className={styles.cart}>
+                <header className={styles.header}>
+                    <div className={styles.headerTop}>
+                        <h1>Mon panier</h1>
+                        {items.length > 0 && (
+                            <button type="button" className={styles.clearButton} onClick={clear}>
+                                Vider le panier
+                            </button>
+                        )}
+                    </div>
+                    <p>
+                        {items.length === 0
+                            ? "Vous n\u2019avez pas encore ajouté de délicieuses spécialités tunisiennes."
+                            : `${totalQuantity} article${totalQuantity > 1 ? "s" : ""} avant le paiement.`}
+                    </p>
+                </header>
+
+                {items.length === 0 ? (
+                    <div className={styles.empty}>
+                        <p>Votre panier est vide pour l’instant.</p>
+                        <Link href="/products">Explorer les produits</Link>
+                    </div>
+                ) : (
+                    <div className={styles.grid}>
+                        <div className={styles.list}>
+                            {items.map(item => {
+                                const lineTotalCents = item.priceCents * item.quantity;
+
+                                const onQuantityInput = (event: ChangeEvent<HTMLInputElement>) => {
+                                    const value = Number.parseInt(event.target.value, 10);
+                                    if (Number.isNaN(value)) {
+                                        updateQuantity(item.id, 1);
+                                        return;
+                                    }
+                                    const safeValue = Math.min(99, Math.max(1, value));
+                                    updateQuantity(item.id, safeValue);
+                                };
+
+                                return (
+                                    <article key={item.id} className={styles.item}>
+                                        <div className={styles.itemImage}>
+                                            <img src={item.image ?? "/images/placeholder.png"} alt={item.name} />
+                                        </div>
+                                        <div className={styles.itemBody}>
+                                            <div className={styles.itemHeader}>
+                                                <h2 className={styles.itemTitle}>{item.name}</h2>
+                                                <button
+                                                    type="button"
+                                                    className={styles.removeButton}
+                                                    onClick={() => removeItem(item.id)}
+                                                >
+                                                    Retirer
+                                                </button>
+                                            </div>
+                                            <span className={styles.price}>
+                                                {formatCurrency(item.priceCents, item.currency)}
+                                            </span>
+                                            <div className={styles.controls}>
+                                                <div className={styles.quantity}>
+                                                    <button
+                                                        type="button"
+                                                        className={styles.quantityButton}
+                                                        onClick={() => decrement(item.id)}
+                                                        aria-label={`Diminuer la quantité de ${item.name}`}
+                                                        disabled={item.quantity <= 1}
+                                                    >
+                                                        −
+                                                    </button>
+                                                    <input
+                                                        className={styles.quantityInput}
+                                                        type="number"
+                                                        min={1}
+                                                        max={99}
+                                                        value={item.quantity}
+                                                        onChange={onQuantityInput}
+                                                        aria-label={`Quantité de ${item.name}`}
+                                                    />
+                                                    <button
+                                                        type="button"
+                                                        className={styles.quantityButton}
+                                                        onClick={() => increment(item.id)}
+                                                        aria-label={`Augmenter la quantité de ${item.name}`}
+                                                    >
+                                                        +
+                                                    </button>
+                                                </div>
+                                                <span className={styles.lineTotal}>
+                                                    {formatCurrency(lineTotalCents, item.currency)}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </article>
+                                );
+                            })}
+                        </div>
+                        <aside className={styles.summary}>
+                            <div className={styles.summaryRow}>
+                                <span>Sous-total</span>
+                                <span>{formatCurrency(subtotalCents, currency)}</span>
+                            </div>
+                            <div className={styles.summaryRow}>
+                                <span>Livraison estimée</span>
+                                <span>
+                                    {shippingCents === 0
+                                        ? subtotalCents === 0
+                                            ? formatCurrency(0, currency)
+                                            : "Offerte"
+                                        : formatCurrency(shippingCents, currency)}
+                                </span>
+                            </div>
+                            <div className={`${styles.summaryRow} ${styles.summaryTotal}`}>
+                                <span>Total</span>
+                                <span>{formatCurrency(totalCents, currency)}</span>
+                            </div>
+                            {missingForFreeShipping > 0 && (
+                                <p className={styles.notice}>
+                                    Plus que {formatCurrency(missingForFreeShipping, currency)} pour profiter de la
+                                    livraison offerte !
+                                </p>
+                            )}
+                            <button
+                                type="button"
+                                className={styles.checkoutButton}
+                                onClick={handleProceedToCheckout}
+                            >
+                                Passer au paiement
+                            </button>
+                            <p className={styles.notice}>
+                                Paiement 100% sécurisé, produits emballés avec soin depuis la Tunisie.
+                            </p>
+                        </aside>
+                    </div>
+                )}
+            </section>
+        </Container>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "../styles/globals.scss";
 import Navbar from "@/components/layout/Navbar/Navbar";
 import Footer from "@/components/layout/Footer/Footer";
 import type { Metadata } from "next";
+import { CartProvider } from "@/features/cart/CartContext";
 
 export const metadata: Metadata = {
     title: "Tounsi-Market",
@@ -12,11 +13,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="fr" suppressHydrationWarning>
-        <body suppressHydrationWarning>
-        <Navbar />
-        <main>{children}</main>
-        <Footer />
-        </body>
+            <body suppressHydrationWarning>
+                <CartProvider>
+                    <Navbar />
+                    <main>{children}</main>
+                    <Footer />
+                </CartProvider>
+            </body>
         </html>
     );
 }

--- a/src/components/layout/Navbar/Navbar.module.scss
+++ b/src/components/layout/Navbar/Navbar.module.scss
@@ -51,7 +51,30 @@
 
 /* Actions */
 .actions { display: flex; align-items: center; gap: 12px; }
-.icon { color: var(--brand-white); text-decoration: none; font-size: 18px; }
+.icon {
+  position: relative;
+  color: var(--brand-white);
+  text-decoration: none;
+  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.badge {
+  position: absolute;
+  top: -6px;
+  right: -10px;
+  background: #fff;
+  color: var(--brand-red);
+  border-radius: 999px;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  min-width: 20px;
+  text-align: center;
+  box-shadow: 0 2px 6px rgba(0,0,0,.2);
+}
 .burger {
   background: transparent; border: 0; color: var(--brand-white);
   font-size: 22px; line-height: 1; display: inline-flex;

--- a/src/components/layout/Navbar/Navbar.tsx
+++ b/src/components/layout/Navbar/Navbar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import styles from "./Navbar.module.scss";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useCart } from "@/features/cart/CartContext";
 
 const links = [
     { href: "/", label: "Accueil" },
@@ -16,6 +17,8 @@ const links = [
 export default function Navbar() {
     const pathname = usePathname();
     const [open, setOpen] = useState(false);
+    const { totalQuantity } = useCart();
+    const hasItems = totalQuantity > 0;
 
     // Empêche le scroll de la page quand le menu mobile est ouvert
     useEffect(() => {
@@ -49,7 +52,11 @@ export default function Navbar() {
                 {/* Actions */}
                 <div className={styles.actions}>
                     <Link className={styles.icon} href="/search" aria-label="Rechercher">🔍</Link>
-                    <Link className={styles.icon} href="/cart" aria-label="Panier">🛒</Link>
+                    <Link className={styles.icon} href="/cart" aria-label="Panier">
+                        <span aria-hidden>🛒</span>
+                        {hasItems && <span className={styles.badge}>{totalQuantity}</span>}
+                        <span className="sr-only">Panier ({totalQuantity})</span>
+                    </Link>
                     <button
                         className={styles.burger}
                         aria-label={open ? "Fermer le menu" : "Ouvrir le menu"}
@@ -81,7 +88,7 @@ export default function Navbar() {
                 ))}
                 <div className={styles.mobileActions}>
                     <Link href="/search" onClick={() => setOpen(false)}>Rechercher</Link>
-                    <Link href="/cart" onClick={() => setOpen(false)}>Panier</Link>
+                    <Link href="/cart" onClick={() => setOpen(false)}>Panier ({totalQuantity})</Link>
                 </div>
             </div>
         </header>

--- a/src/features/cart/CartContext.tsx
+++ b/src/features/cart/CartContext.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useReducer } from "react";
+import type { Product } from "@/services/products.service";
+
+type CartItem = {
+    id: string;
+    name: string;
+    priceCents: number;
+    currency: string;
+    image?: string;
+    quantity: number;
+};
+
+type CartState = {
+    items: CartItem[];
+};
+
+type Action =
+    | { type: "INITIALIZE"; payload: CartItem[] }
+    | { type: "ADD_ITEM"; payload: CartItem }
+    | { type: "REMOVE_ITEM"; payload: { id: string } }
+    | { type: "INCREMENT"; payload: { id: string } }
+    | { type: "DECREMENT"; payload: { id: string } }
+    | { type: "UPDATE_QUANTITY"; payload: { id: string; quantity: number } }
+    | { type: "CLEAR" };
+
+type CartContextValue = {
+    items: CartItem[];
+    currency: string;
+    subtotalCents: number;
+    totalQuantity: number;
+    addItem: (product: Product, quantity?: number) => void;
+    removeItem: (id: string) => void;
+    increment: (id: string) => void;
+    decrement: (id: string) => void;
+    updateQuantity: (id: string, quantity: number) => void;
+    clear: () => void;
+};
+
+const STORAGE_KEY = "tounsi-market-cart";
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+function reducer(state: CartState, action: Action): CartState {
+    switch (action.type) {
+        case "INITIALIZE":
+            return { items: action.payload };
+        case "ADD_ITEM": {
+            const existing = state.items.find(item => item.id === action.payload.id);
+            if (!existing) {
+                return { items: [...state.items, action.payload] };
+            }
+
+            return {
+                items: state.items.map(item =>
+                    item.id === action.payload.id
+                        ? { ...item, quantity: item.quantity + action.payload.quantity }
+                        : item,
+                ),
+            };
+        }
+        case "REMOVE_ITEM":
+            return { items: state.items.filter(item => item.id !== action.payload.id) };
+        case "INCREMENT":
+            return {
+                items: state.items.map(item =>
+                    item.id === action.payload.id
+                        ? { ...item, quantity: item.quantity + 1 }
+                        : item,
+                ),
+            };
+        case "DECREMENT":
+            return {
+                items: state.items
+                    .map(item =>
+                        item.id === action.payload.id
+                            ? { ...item, quantity: Math.max(1, item.quantity - 1) }
+                            : item,
+                    ),
+            };
+        case "UPDATE_QUANTITY":
+            return {
+                items: state.items.map(item =>
+                    item.id === action.payload.id
+                        ? { ...item, quantity: Math.max(1, action.payload.quantity) }
+                        : item,
+                ),
+            };
+        case "CLEAR":
+            return { items: [] };
+        default:
+            return state;
+    }
+}
+
+const initialState: CartState = { items: [] };
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+    const [state, dispatch] = useReducer(reducer, initialState);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        try {
+            const stored = window.localStorage.getItem(STORAGE_KEY);
+            if (!stored) return;
+            const parsed = JSON.parse(stored) as CartItem[];
+            if (Array.isArray(parsed)) {
+                dispatch({ type: "INITIALIZE", payload: parsed });
+            }
+        } catch (error) {
+            console.error("CartProvider: impossible de lire le panier depuis le stockage", error);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state.items));
+        } catch (error) {
+            console.error("CartProvider: impossible d'enregistrer le panier", error);
+        }
+    }, [state.items]);
+
+    const value = useMemo<CartContextValue>(() => {
+        const subtotalCents = state.items.reduce(
+            (total, item) => total + item.priceCents * item.quantity,
+            0,
+        );
+        const totalQuantity = state.items.reduce((total, item) => total + item.quantity, 0);
+        const currency = state.items[0]?.currency ?? "EUR";
+
+        return {
+            items: state.items,
+            currency,
+            subtotalCents,
+            totalQuantity,
+            addItem: (product, quantity = 1) => {
+                dispatch({
+                    type: "ADD_ITEM",
+                    payload: {
+                        id: product.id,
+                        name: product.name,
+                        priceCents: product.priceCents,
+                        currency: product.currency,
+                        image: product.images?.[0],
+                        quantity,
+                    },
+                });
+            },
+            removeItem: (id: string) => dispatch({ type: "REMOVE_ITEM", payload: { id } }),
+            increment: (id: string) => dispatch({ type: "INCREMENT", payload: { id } }),
+            decrement: (id: string) => dispatch({ type: "DECREMENT", payload: { id } }),
+            updateQuantity: (id: string, quantity: number) =>
+                dispatch({ type: "UPDATE_QUANTITY", payload: { id, quantity } }),
+            clear: () => dispatch({ type: "CLEAR" }),
+        };
+    }, [state.items]);
+
+    return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart() {
+    const context = useContext(CartContext);
+    if (!context) {
+        throw new Error("useCart doit être utilisé dans un CartProvider");
+    }
+    return context;
+}
+
+export type { CartItem };

--- a/src/features/product/ProductView/ProductView.module.scss
+++ b/src/features/product/ProductView/ProductView.module.scss
@@ -42,6 +42,48 @@
 .price { margin-top: 8px; color: var(--brand-red); font-weight: 700; font-size: 1.25rem; }
 .desc { margin-top: 12px; color: #333; }
 
+.quantity {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+
+  span {
+    font-size: .95rem;
+    color: var(--gray-900);
+  }
+}
+
+.quantityControl {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--gray-300);
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+
+  button {
+    width: 36px;
+    height: 36px;
+    border: 0;
+    background: transparent;
+    font-size: 18px;
+    cursor: pointer;
+    transition: background .15s ease;
+
+    &:hover { background: rgba(0,0,0,.05); }
+  }
+
+  input {
+    width: 48px;
+    border: 0;
+    text-align: center;
+    font-weight: 600;
+    font-size: 1rem;
+  }
+}
+
 .actions {
   margin-top: 16px;
   display: flex;
@@ -79,6 +121,13 @@
   font-weight: 600;
 
   &:hover { background: #fff0f0; }
+}
+
+.feedback {
+  margin-top: 8px;
+  color: #2e7d32;
+  font-size: .9rem;
+  font-weight: 600;
 }
 
 .meta { margin-top: 10px; color: #666; font-size: .95rem; }

--- a/src/features/product/ProductView/ProductView.tsx
+++ b/src/features/product/ProductView/ProductView.tsx
@@ -1,11 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import type { ChangeEvent } from "react";
 import styles from "./ProductView.module.scss";
 import Link from "next/link";
 import type { Product } from "@/services/products.service";
+import { useCart } from "@/features/cart/CartContext";
 
 type Props = { product: Product };
 
 export default function ProductView({ product }: Props) {
     const img = product.images?.[0] || "/images/placeholder.png";
+    const { addItem } = useCart();
+    const [quantity, setQuantity] = useState(1);
+    const [added, setAdded] = useState(false);
+
+    const increase = () => setQuantity(q => Math.min(99, q + 1));
+    const decrease = () => setQuantity(q => Math.max(1, q - 1));
+
+    const onQuantityChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const value = Number.parseInt(event.target.value, 10);
+        if (Number.isNaN(value)) {
+            setQuantity(1);
+            return;
+        }
+        setQuantity(Math.min(99, Math.max(1, value)));
+    };
+
+    const handleAddToCart = () => {
+        addItem(product, quantity);
+        setAdded(true);
+        setTimeout(() => setAdded(false), 2000);
+    };
 
     return (
         <section className={styles.product}>
@@ -28,14 +54,35 @@ export default function ProductView({ product }: Props) {
                     {product.description && (
                         <p className={styles.desc}>{product.description}</p>
                     )}
+                    <div className={styles.quantity}> 
+                        <span>Quantité</span>
+                        <div className={styles.quantityControl}>
+                            <button type="button" onClick={decrease} aria-label="Diminuer la quantité">−</button>
+                            <input
+                                type="number"
+                                min={1}
+                                max={99}
+                                value={quantity}
+                                onChange={onQuantityChange}
+                                aria-label="Quantité"
+                            />
+                            <button type="button" onClick={increase} aria-label="Augmenter la quantité">+</button>
+                        </div>
+                    </div>
                     <div className={styles.actions}>
-                        <button className={styles.cta} aria-label="Ajouter au panier">
+                        <button
+                            type="button"
+                            className={styles.cta}
+                            aria-label="Ajouter au panier"
+                            onClick={handleAddToCart}
+                        >
                             Ajouter au panier
                         </button>
                         <Link href="/cart" className={styles.secondary}>
                             Voir le panier
                         </Link>
                     </div>
+                    {added && <p className={styles.feedback}>Ajouté au panier ✅</p>}
                     <p className={styles.meta}>Disponibilité : {product.stock ?? 0} en stock</p>
                 </div>
             </div>

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,21 @@
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+function getFormatter(currency: string) {
+    if (!formatterCache.has(currency)) {
+        formatterCache.set(
+            currency,
+            new Intl.NumberFormat("fr-FR", {
+                style: "currency",
+                currency,
+                minimumFractionDigits: 2,
+            }),
+        );
+    }
+
+    return formatterCache.get(currency)!;
+}
+
+export function formatCurrency(amountCents: number, currency: string = "EUR") {
+    const formatter = getFormatter(currency);
+    return formatter.format(amountCents / 100);
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -24,3 +24,15 @@ img {
   max-width: 100%;
   display: block;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add a cart context with persistence and expose it from the root layout
- build a responsive cart page with quantity controls, totals and clear/proceed actions
- connect product detail and navigation UI to the cart, including quantity picker and badge

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e01cfaaf3083268acfde9a3b4605cd